### PR TITLE
Event trigger for the whole form Validated

### DIFF
--- a/js/validator.js
+++ b/js/validator.js
@@ -160,10 +160,15 @@
   }
 
   Validator.prototype.validate = function () {
+    var self = this
     var delay = this.options.delay
 
     this.options.delay = 0
-    this.$element.find(inputSelector).trigger('input.bs.validator')
+    $.when(
+      this.$element.find(inputSelector).trigger('input.bs.validator')
+    ).then(function() {
+      self.$element.trigger('form.validated.bs.validator')
+    });
     this.options.delay = delay
 
     return this


### PR DESCRIPTION
It is not possible to determine when the form was fully validated.
This simple patch manage to trigger an event after all fields are validated.

fix #69 and closes #116